### PR TITLE
Fix compacting drawer icons

### DIFF
--- a/src/main/java/eu/pb4/extdrawpatch/impl/model/CompactingDrawerModel.java
+++ b/src/main/java/eu/pb4/extdrawpatch/impl/model/CompactingDrawerModel.java
@@ -1,6 +1,8 @@
 package eu.pb4.extdrawpatch.impl.model;
 
 import io.github.mattidragon.extendeddrawers.block.CompactingDrawerBlock;
+import io.github.mattidragon.extendeddrawers.block.entity.CompactingDrawerBlockEntity;
+import io.github.mattidragon.extendeddrawers.registry.ModBlocks;
 import io.github.mattidragon.extendeddrawers.storage.CompactingDrawerStorage;
 import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.minecraft.block.BlockState;
@@ -28,29 +30,30 @@ public class CompactingDrawerModel extends BaseDrawerModel {
         this.right.setRotation(pitch, yaw);
     }
 
-    public void update(CompactingDrawerStorage storage) {
-        var arr = storage.getSlotArray();
+    public void update(CompactingDrawerBlockEntity drawer) {
+        CompactingDrawerStorage storage = drawer.storage;
+        var arr = storage.getActiveSlotArray();
         var mat = mat();
 
         if (arr.length >= 1) {
-            var x = arr[0];
-            this.left.updateStorage(this, x.getResource(), x.getAmount(), storage, mat);
-        } else {
-            this.left.updateStorage(this, ItemVariant.blank(), 0, storage, mat);
-        }
-
-        if (arr.length >= 2) {
-            var x = arr[1];
+            var x = ModBlocks.COMPACTING_DRAWER.getSlot(drawer, ModBlocks.COMPACTING_DRAWER.getSlotIndex(drawer, new Vec2f(0.5f, 0.25f)));
             this.top.updateStorage(this, x.getResource(), x.getAmount(), storage, mat);
         } else {
             this.top.updateStorage(this, ItemVariant.blank(), 0, storage, mat);
         }
 
-        if (arr.length >= 3) {
-            var x = arr[2];
+        if (arr.length >= 2) {
+            var x = ModBlocks.COMPACTING_DRAWER.getSlot(drawer, ModBlocks.COMPACTING_DRAWER.getSlotIndex(drawer, new Vec2f(0.75f, 0.75f)));
             this.right.updateStorage(this, x.getResource(), x.getAmount(), storage, mat);
         } else {
             this.right.updateStorage(this, ItemVariant.blank(), 0, storage, mat);
+        }
+
+        if (arr.length >= 3) {
+            var x = ModBlocks.COMPACTING_DRAWER.getSlot(drawer, ModBlocks.COMPACTING_DRAWER.getSlotIndex(drawer, new Vec2f(0.25f, 0.75f)));
+            this.left.updateStorage(this, x.getResource(), x.getAmount(), storage, mat);
+        } else {
+            this.left.updateStorage(this, ItemVariant.blank(), 0, storage, mat);
         }
         this.tick();
     }

--- a/src/main/java/eu/pb4/extdrawpatch/mixin/mod/block/be/CompactingDrawerBlockEntityMixin.java
+++ b/src/main/java/eu/pb4/extdrawpatch/mixin/mod/block/be/CompactingDrawerBlockEntityMixin.java
@@ -1,22 +1,15 @@
 package eu.pb4.extdrawpatch.mixin.mod.block.be;
 
 import eu.pb4.extdrawpatch.impl.model.CompactingDrawerModel;
-import eu.pb4.extdrawpatch.impl.model.ShadowDrawerModel;
 import eu.pb4.factorytools.api.block.BlockEntityExtraListener;
 import eu.pb4.polymer.virtualentity.api.attachment.BlockAwareAttachment;
 import io.github.mattidragon.extendeddrawers.block.entity.CompactingDrawerBlockEntity;
-import io.github.mattidragon.extendeddrawers.block.entity.ShadowDrawerBlockEntity;
 import io.github.mattidragon.extendeddrawers.block.entity.StorageDrawerBlockEntity;
-import io.github.mattidragon.extendeddrawers.storage.CompactingDrawerStorage;
-import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.minecraft.block.BlockState;
-import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.chunk.WorldChunk;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -24,7 +17,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(CompactingDrawerBlockEntity.class)
 public abstract class CompactingDrawerBlockEntityMixin extends StorageDrawerBlockEntity implements BlockEntityExtraListener {
-    @Shadow @Final public CompactingDrawerStorage storage;
     @Unique
     private CompactingDrawerModel model;
 
@@ -36,14 +28,14 @@ public abstract class CompactingDrawerBlockEntityMixin extends StorageDrawerBloc
     public void onSlotChanged(boolean sortingChanged) {
         super.onSlotChanged(sortingChanged);
         if (this.model != null) {
-            this.model.update(this.storage);
+            this.model.update((CompactingDrawerBlockEntity) (Object) this);
         }
     }
 
     @Inject(method = "readComponents", at = @At("TAIL"))
     private void onReadComponents(ComponentsAccess components, CallbackInfo ci) {
         if (this.model != null) {
-            this.model.update(this.storage);
+            this.model.update((CompactingDrawerBlockEntity) (Object) this);
         }
     }
 
@@ -52,7 +44,7 @@ public abstract class CompactingDrawerBlockEntityMixin extends StorageDrawerBloc
         var x = BlockAwareAttachment.get(chunk, this.pos);
         if (x != null && x.holder() instanceof CompactingDrawerModel model) {
             this.model = model;
-            model.update(this.storage);
+            model.update((CompactingDrawerBlockEntity) (Object) this);
         }
     }
 }


### PR DESCRIPTION
Fixes the icon order _(was wrong when there were less than 3 active slots)_ and only considers active slots _(rendered incorrect item counts on empty slots)_